### PR TITLE
More consistent use of options

### DIFF
--- a/routing_test.go
+++ b/routing_test.go
@@ -89,7 +89,7 @@ func TestRoutingDiscovery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pis, err := FindPeers(ctx, d2, "/test", 20)
+	pis, err := FindPeers(ctx, d2, "/test", Limit(20))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/util.go
+++ b/util.go
@@ -11,10 +11,10 @@ import (
 var log = logging.Logger("discovery")
 
 // FindPeers is a utility function that synchonously collects peers from a Discoverer
-func FindPeers(ctx context.Context, d Discoverer, ns string, limit int) ([]pstore.PeerInfo, error) {
-	res := make([]pstore.PeerInfo, 0, limit)
+func FindPeers(ctx context.Context, d Discoverer, ns string, opts ...Option) ([]pstore.PeerInfo, error) {
+	var res []pstore.PeerInfo
 
-	ch, err := d.FindPeers(ctx, ns, Limit(limit))
+	ch, err := d.FindPeers(ctx, ns, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -27,10 +27,10 @@ func FindPeers(ctx context.Context, d Discoverer, ns string, limit int) ([]pstor
 }
 
 // Advertise is a utility function that persistently advertises a service through an Advertiser
-func Advertise(ctx context.Context, a Advertiser, ns string) {
+func Advertise(ctx context.Context, a Advertiser, ns string, opts ...Option) {
 	go func() {
 		for {
-			ttl, err := a.Advertise(ctx, ns)
+			ttl, err := a.Advertise(ctx, ns, opts...)
 			if err != nil {
 				log.Debugf("Error advertising %s: %s", ns, err.Error())
 				if ctx.Err() != nil {


### PR DESCRIPTION
- The routing-backed discovery implementation respects the TTL option in `Advertise`
- The utility functions `Advertise` and `FindPeers` accept options