### PR TITLE
Put period at end of sentence

### DIFF
--- a/routing.go
+++ b/routing.go
@@ -13,7 +13,7 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
-// RoutingDiscovery is an implementation of discovery using ContentRouting
+// RoutingDiscovery is an implementation of discovery using ContentRouting.
 // Namespaces are translated to Cids using the SHA256 hash.
 type RoutingDiscovery struct {
 	routing.ContentRouting


### PR DESCRIPTION
The generated documentation looks a little funny without a period:
https://pkg.go.dev/github.com/libp2p/go-libp2p-discovery?tab=doc#RoutingDiscovery
https://godoc.org/github.com/libp2p/go-libp2p-discovery#RoutingDiscovery