### PR TITLE
remove dependency on the go-libp2p-peerstore/addr package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/ipfs/go-log/v2 v2.4.0
 	github.com/libp2p/go-libp2p-blankhost v0.2.0
 	github.com/libp2p/go-libp2p-core v0.11.0
-	github.com/libp2p/go-libp2p-peerstore v0.4.0
 	github.com/libp2p/go-libp2p-swarm v0.8.0
 	github.com/multiformats/go-multihash v0.0.15
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c


### PR DESCRIPTION
This code, as the previous code, assume that the addresses in `peer.AddrInfo` are unique (in subtly different ways).

Needed for https://github.com/libp2p/go-libp2p-peerstore/issues/181.