### PR TITLE
remove dependency on the go-libp2p-peerstore/addr package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/ipfs/go-log/v2 v2.4.0
 	github.com/libp2p/go-libp2p-blankhost v0.2.0
 	github.com/libp2p/go-libp2p-core v0.11.0
-	github.com/libp2p/go-libp2p-peerstore v0.4.0
 	github.com/libp2p/go-libp2p-swarm v0.8.0
+	github.com/multiformats/go-multiaddr v0.4.0
 	github.com/multiformats/go-multihash v0.0.15
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )


### PR DESCRIPTION
This is an alternative to #79, that doesn't make any assumptions about the uniqueness of addresses. Note that there's still a weird assumption of uniqueness in this line: `if len(combinedAddrs) > len(prevAi.Addrs)`, but this is nothing that's changed by this PR.

Closes #79.

Also note that that the runtime behavior of this function is now `O(N^2)`, previously `O(N)`, but we now don't need to allocate a map, so that's probably an improvement, assuming that the `AddrInfo` doesn't contain a ton of addresses.