### PR TITLE
remove dependency on the go-libp2p-peerstore/addr package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/ipfs/go-log/v2 v2.4.0
 	github.com/libp2p/go-libp2p-blankhost v0.2.0
 	github.com/libp2p/go-libp2p-core v0.11.0
-	github.com/libp2p/go-libp2p-peerstore v0.4.0
 	github.com/libp2p/go-libp2p-swarm v0.8.0
+	github.com/multiformats/go-multiaddr v0.4.0
 	github.com/multiformats/go-multihash v0.0.15
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )


### PR DESCRIPTION
Closes #79.

This duplicates the logic we currently have. This can be optimized, but this should probably part of a larger refactor.